### PR TITLE
Changed LanguageServerProtocol dep version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 		.library(name: "LanguageServer", targets: ["LanguageServer"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/ChimeHQ/LanguageServerProtocol", from: "0.11.0"),
+		.package(url: "https://github.com/ChimeHQ/LanguageServerProtocol", from: "0.13.4"),
 	],
 	targets: [
 		.target(name: "LanguageServer", dependencies: ["LanguageServerProtocol"]),


### PR DESCRIPTION
Bumped from "from: 0.11.0" to "from: 0.13.2"

As some types used in this code like `PrepareTypeHeirarchyResponse` or `TypeHierarchyPrepareParams` are only implement in the release `0.13.4` of the `LanguageServerProtocol`, as shown in [this release](https://github.com/ChimeHQ/LanguageServerProtocol/releases/tag/0.13.4)