### PR TITLE
Add typeHierarchySubtypes and typeHierarchySupertypes to default implementations

### DIFF
--- a/Sources/LanguageServer/RequestHandler.swift
+++ b/Sources/LanguageServer/RequestHandler.swift
@@ -233,5 +233,7 @@ public extension RequestHandler {
 	func semanticTokensRange(id: JSONId, params: SemanticTokensRangeParams) async -> Response<SemanticTokensResponse> { .failure(NotImplementedError) }
 	func callHierarchyIncomingCalls(id: JSONId, params: CallHierarchyIncomingCallsParams) async -> Response<CallHierarchyIncomingCallsResponse> { .failure(NotImplementedError) }
 	func callHierarchyOutgoingCalls(id: JSONId, params: CallHierarchyOutgoingCallsParams) async -> Response<CallHierarchyOutgoingCallsResponse> { .failure(NotImplementedError) }
+	func typeHierarchySubtypes(id: JSONId, params: TypeHierarchySubtypesParams) async -> Response<TypeHierarchySubtypesResponse> { .failure(NotImplementedError) }
+	func typeHierarchySupertypes(id: JSONId, params: TypeHierarchySupertypesParams) async -> Response<TypeHierarchySupertypesResponse> { .failure(NotImplementedError) }
 	func custom(id: JSONId, method: String, params: LSPAny) async -> Response<LSPAny> { .failure(NotImplementedError) }
 }

--- a/Tests/LanguageServerTests/LanguageServerTests.swift
+++ b/Tests/LanguageServerTests/LanguageServerTests.swift
@@ -9,4 +9,16 @@ final class LanguageServerTests: XCTestCase {
         // Defining Test Cases and Test Methods
         // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
     }
+	
+	/// A compile-time check to ensure `RequestHandler` and `NotificationHandler`
+	/// continue to provide default implementations for every protocol requirement.
+	func testRequestHandlerAndNotificationHandlerHaveCompleteDefaults() throws {
+		struct MinimalRequestHandler: RequestHandler {
+			func internalError(_ error: Error) async {}
+		}
+	
+		struct MinimalNotificationHandler: NotificationHandler {
+			func internalError(_ error: Error) async {}
+		}
+	}
 }


### PR DESCRIPTION
When trying to use this package, I was getting compile errors like:

```
error: type 'xxx' does not conform to protocol 'RequestHandler'

/Users/isla/source/swift-test/.build/checkouts/LanguageServer/Sources/LanguageServer/RequestHandler.swift:59:7: note: protocol requires function 'typeHierarchySubtypes(id:params:)' with type '(JSONId, TypeHierarchySubtypesParams) async -> MinimalHandler.Response<TypeHierarchySubtypesResponse>' (aka '(JSONId, TypeHierarchySubtypesParams) async -> Result<Optional<Array<TypeHierarchyItem>>, JSONRPCResponseError<JSONValue>>')
 57 | 	func callHierarchyIncomingCalls(id: JSONId, params: CallHierarchyIncomingCallsParams) async -> Response<CallHierarchyIncomingCallsResponse>
 58 | 	func callHierarchyOutgoingCalls(id: JSONId, params: CallHierarchyOutgoingCallsParams) async -> Response<CallHierarchyOutgoingCallsResponse>
 59 | 	func typeHierarchySubtypes(id: JSONId, params: TypeHierarchySubtypesParams) async -> Response<TypeHierarchySubtypesResponse>
    |       `- note: protocol requires function 'typeHierarchySubtypes(id:params:)' with type '(JSONId, TypeHierarchySubtypesParams) async -> MinimalHandler.Response<TypeHierarchySubtypesResponse>' (aka '(JSONId, TypeHierarchySubtypesParams) async -> Result<Optional<Array<TypeHierarchyItem>>, JSONRPCResponseError<JSONValue>>')
 60 | 	func typeHierarchySupertypes(id: JSONId, params: TypeHierarchySupertypesParams) async -> Response<TypeHierarchySupertypesResponse>
    |       `- note: protocol requires function 'typeHierarchySupertypes(id:params:)' with type '(JSONId, TypeHierarchySupertypesParams) async -> MinimalHandler.Response<TypeHierarchySupertypesResponse>' (aka '(JSONId, TypeHierarchySupertypesParams) async -> Result<Optional<Array<TypeHierarchyItem>>, JSONRPCResponseError<JSONValue>>')
 61 | 	func custom(id: JSONId, method: String, params: LSPAny) async -> Response<LSPAny>
 62 | }

```
Suggesting that RequestHandler's default-implementation extension is missing `typeHierarchySubtypes` and `typeHierarchySupertypes`

I was able to reproduce with a simple example:
```
import LanguageServer
import LanguageServerProtocol

struct MinimalHandler: RequestHandler {
    func internalError(_ error: Error) async {}
}
```

Looks like this was just missed here when adding those: https://github.com/ChimeHQ/LanguageServer/commit/ea769da5e2cda7db1cb3f2de7b4149c9e535cbd5